### PR TITLE
Inflight_events calculation is backwards

### DIFF
--- a/check_logstash
+++ b/check_logstash
@@ -396,7 +396,7 @@ class CheckLogstash
   def inflight_events_health(result)
     # check if inflight events are outside of threshold
     # find a way to reuse the already computed inflight events
-    inflight_events = (result.get('pipeline.events.out') - result.get('pipeline.events.in')).to_i
+    inflight_events = (result.get('pipeline.events.in') - result.get('pipeline.events.out')).to_i
     inflight_events_report = format(INFLIGHT_EVENTS_REPORT, inflight_events)
     if critical_inflight_events_max && critical_inflight_events_max < inflight_events
       Critical.new(inflight_events_report)

--- a/check_logstash
+++ b/check_logstash
@@ -329,7 +329,7 @@ class CheckLogstash
     percent_file_descriptors = (open_file_descriptors.to_f / max_file_descriptors) * 100
     warn_file_descriptors = (max_file_descriptors / 100) * warning_file_descriptor_percent
     crit_file_descriptors = (max_file_descriptors / 100) * critical_file_descriptor_percent
-    inflight_events = (result.get('pipeline.events.out') - result.get('pipeline.events.in')).to_i
+    inflight_events = (result.get('pipeline.events.in') - result.get('pipeline.events.out')).to_i
 
     [
       PerfData.report_percent(result, 'process.cpu.percent', warning_cpu_percent, critical_cpu_percent, 0, 100),

--- a/lib/check_logstash.rb
+++ b/lib/check_logstash.rb
@@ -329,7 +329,7 @@ class CheckLogstash
     percent_file_descriptors = (open_file_descriptors.to_f / max_file_descriptors) * 100
     warn_file_descriptors = (max_file_descriptors / 100) * warning_file_descriptor_percent
     crit_file_descriptors = (max_file_descriptors / 100) * critical_file_descriptor_percent
-    inflight_events = (result.get('pipeline.events.out') - result.get('pipeline.events.in')).to_i
+    inflight_events = (result.get('pipeline.events.in')- result.get('pipeline.events.out')).to_i
 
     [
       PerfData.report_percent(result, 'process.cpu.percent', warning_cpu_percent, critical_cpu_percent, 0, 100),

--- a/lib/check_logstash.rb
+++ b/lib/check_logstash.rb
@@ -396,7 +396,7 @@ class CheckLogstash
   def inflight_events_health(result)
     # check if inflight events are outside of threshold
     # find a way to reuse the already computed inflight events
-    inflight_events = (result.get('pipeline.events.out') - result.get('pipeline.events.in')).to_i
+    inflight_events = (result.get('pipeline.events.in') - result.get('pipeline.events.out')).to_i
     inflight_events_report = format(INFLIGHT_EVENTS_REPORT, inflight_events)
     if critical_inflight_events_max && critical_inflight_events_max < inflight_events
       Critical.new(inflight_events_report)


### PR DESCRIPTION
I am interpreting "inflight" as the number of events that are currently queued for processing in logstash.   So, it would be, the "number of received events" minus the "number of sent events", or put another way, "in - out".  I don't see why "out - in" (what is specified in the code) would ever produce a positive number. Why would you have sent more events than you received?

But I am also confused since this would certainly show up in normal usage (unless you are always getting zero?).   

Or am I misunderstanding what is meant by "inflight"?